### PR TITLE
Integrated automatic refresh token logic in the HTTP interceptor to handle 401 Unauthorized errors

### DIFF
--- a/PaymentGatewayApp/PaymentGatewayApp.Server/Program.cs
+++ b/PaymentGatewayApp/PaymentGatewayApp.Server/Program.cs
@@ -15,7 +15,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowAngularClient",
         policy =>
         {
-            policy.WithOrigins("http://localhost:65283") // Frontend dev server URL
+            policy.WithOrigins("http://localhost:60371") // Frontend dev server URL
                   .AllowAnyMethod()                      // Allow all HTTP methods (GET, POST, etc.)
                   .AllowAnyHeader()                      // Allow any HTTP headers
                   .AllowCredentials();                   // Support sending cookies or auth headers
@@ -63,7 +63,7 @@ app.UseSpa(spa =>
     if (app.Environment.IsDevelopment())
     {
         // Proxy Angular dev server during development for live reload and fast builds
-        spa.UseProxyToSpaDevelopmentServer("http://localhost:65283");
+        spa.UseProxyToSpaDevelopmentServer("http://localhost:60371");
     }
 });
 app.Run();

--- a/PaymentGatewayApp/PaymentGatewayApp.Server/appsettings.json
+++ b/PaymentGatewayApp/PaymentGatewayApp.Server/appsettings.json
@@ -14,7 +14,7 @@
   },
   "JwtSettings": {
     "Secret": "qwertyuiolkjhnbvcsasfdghjnbxzdfbvnvcsasdfghsdfghdsdfgnbfdsfghgfdsfgdsfdgbbvcxzdsfdhguyiaewwwxcfghjzseljkajejvnshwoerhwjnfjsjahsbfehw",
-    "ExpiryMinutes": 60,
+    "ExpiryMinutes": 1,
     "Issuer": "PaymentGateway",
     "Audience": "PaymentGateway"
   }

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/DTOs/token-request.dto.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/DTOs/token-request.dto.ts
@@ -1,0 +1,4 @@
+export class TokenRequest_DTO{
+    public AccessToken: string | null =  '';
+    public RefreshToken: string | null = '';
+}

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/app.module.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { HttpClientModule } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
@@ -6,11 +6,14 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
 import { LoginComponent } from './login/login.component';
 import { NavbarComponent } from './navbar/navbar.component';
+import { PaymentProcessComponent } from './payment/payment-process.component';
+import { AuthInterceptor } from './interceptor/auth.interceptor';
 @NgModule({
   declarations: [
     AppComponent,
     LoginComponent,
-    NavbarComponent
+    NavbarComponent,
+    PaymentProcessComponent
   ],
   imports: [
     BrowserModule,
@@ -19,7 +22,12 @@ import { NavbarComponent } from './navbar/navbar.component';
     ReactiveFormsModule,
     HttpClientModule
   ],
-  providers: [],
+  providers: [
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
+      multi: true,
+    }],
   bootstrap: [AppComponent]
 })
-export class AppModule {}
+export class AppModule { }

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/interceptor/auth.interceptor.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/interceptor/auth.interceptor.ts
@@ -1,0 +1,99 @@
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from "@angular/common/http";
+import { BehaviorSubject, catchError, filter, Observable, switchMap, take, throwError } from "rxjs";
+import { TokenRequest_DTO } from "../DTOs/token-request.dto";
+import { AuthService } from "../service/authentication.service";
+import { ApiService } from "../service/api.service";
+import { Injectable } from "@angular/core";
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+    private isRefreshing = false;
+    private refreshTokenSubject = new BehaviorSubject<string | null>(null);
+
+    constructor(private authService: AuthService, private apiService: ApiService) { }
+
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        const accessToken = this.authService.getAccessToken();
+
+        // Clone and attach access token
+        let authReq = req;
+        if (accessToken) {
+            authReq = req.clone({
+                setHeaders: {
+                    Authorization: `Bearer ${accessToken}`
+                }
+            });
+        }
+
+        // Proceed with request
+        return next.handle(authReq).pipe(
+            catchError(error => {
+                if (error instanceof HttpErrorResponse && error.status === 401) {
+                    return this.handle401Error(authReq, next);
+                } else {
+                    return throwError(() => error);
+                }
+            })
+        );
+    }
+
+    private handle401Error(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        if (!this.isRefreshing) {
+            this.isRefreshing = true;
+            this.refreshTokenSubject.next(null);
+
+            const tokenRequest: TokenRequest_DTO = {
+                AccessToken: this.authService.getAccessToken(),
+                RefreshToken: this.authService.getRefreshToken()
+            };
+
+            return this.authService.FetchRefreshToken(tokenRequest).pipe(
+                switchMap((res: any) => {
+                    if (res && res.accessToken) {
+                        this.isRefreshing = false;
+                        this.authService.setToken(res.accessToken, res.refreshToken); // Save new tokens
+                        this.refreshTokenSubject.next(res.accessToken);
+
+                        // Retry the original request with new token
+                        const retryReq = req.clone({
+                            setHeaders: {
+                                Authorization: `Bearer ${res.accessToken}`
+                            }
+                        });
+
+                        return next.handle(retryReq);
+                    } else {
+                        // Invalid response - maybe no access token
+                        this.handleAuthError();
+                        return throwError(() => new Error('Invalid token refresh response'));
+                    }
+                })
+            ).pipe(
+                catchError(err => {
+                    // This catchError only triggers if refresh fails
+                    this.handleAuthError();
+                    return throwError(() => err);
+                })
+            );
+        } else {
+            // Wait for the refreshing process to complete
+            return this.refreshTokenSubject.pipe(
+                filter(token => token !== null),
+                take(1),
+                switchMap((token) => {
+                    const retryReq = req.clone({
+                        setHeaders: {
+                            Authorization: `Bearer ${token}`
+                        }
+                    });
+                    return next.handle(retryReq);
+                })
+            );
+        }
+    }
+
+    private handleAuthError() {
+        this.authService.clearTokens();
+        window.location.href = '/login';
+    }
+}

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/login/login.component.html
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/login/login.component.html
@@ -26,3 +26,6 @@
         </div>
     </div>
 </div>
+<div *ngIf="IsPaymentAllowed">
+    <app-payment-process></app-payment-process>
+</div>

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/login/login.component.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/login/login.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ApiService } from '../service/api.service';
+import { AuthService } from '../service/authentication.service';
+import { TokenRequest_DTO } from '../DTOs/token-request.dto';
 
 @Component({
     selector: 'app-login',
@@ -10,7 +12,9 @@ import { ApiService } from '../service/api.service';
 export class LoginComponent implements OnInit {
 
     loginForm!: FormGroup;
-    constructor(private fb: FormBuilder, private router: Router, private apiService: ApiService) {
+    IsPaymentAllowed: boolean = false;
+    token: TokenRequest_DTO = new TokenRequest_DTO();
+    constructor(private fb: FormBuilder, private router: Router, private apiService: ApiService, public authService: AuthService) {
         this.loginForm = this.fb.group({
             UserName: ['', [Validators.required]],
             Password: ['', [Validators.required, Validators.minLength(6)]]
@@ -25,9 +29,9 @@ export class LoginComponent implements OnInit {
             this.apiService.Login(this.loginForm.value).subscribe({
                 next: (response: any) => {
                     if (response && response.accessToken) {
-                        console.log(response);
-                        // this.authService.login(response.accessToken);
-                        // this.router.navigate(['/dashboard']);
+                        this.token = response;
+                        this.authService.setToken(response.accessToken, response.refreshToken);
+                        this.IsPaymentAllowed = true;
                     } else {
                         alert('Invalid login response');
                     }
@@ -38,6 +42,4 @@ export class LoginComponent implements OnInit {
             });
         }
     }
-
-
 }

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/payment/payment-process.component.html
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/payment/payment-process.component.html
@@ -1,0 +1,92 @@
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="">
+            <div class="card">
+                <div class="card-body">
+                    <h3 class="text-center">Payment Checkout</h3>
+                    <form [formGroup]="checkoutForm" (ngSubmit)="submitPayment()">
+                        <div class="mb-1">
+                            <label>Customer Name</label>
+                            <input type="text" class="form-control" formControlName="FullName">
+                            <div *ngIf="checkoutForm.get('FullName')?.invalid && checkoutForm.get('FullName')?.touched" class="text-danger">
+                                Name is required.
+                            </div>
+                        </div>
+                        <div class="mb-1">
+                            <label>Email</label>
+                            <input type="email" class="form-control" formControlName="Email">
+                            <div *ngIf="checkoutForm.get('Email')?.invalid && checkoutForm.get('Email')?.touched" class="text-danger">
+                                Valid Email is required.
+                            </div>
+                        </div>
+                        <div class="mb-1">
+                            <label>Currency</label>
+                            <input type="text" class="form-control" formControlName="Currency">
+                            <div *ngIf="checkoutForm.get('Currency')?.invalid && checkoutForm.get('Currency')?.touched" class="text-danger">
+                                Currency is required.
+                            </div>
+                        </div>
+                        <div class="mb-1">
+                            <label>Amount</label>
+                            <input type="text" class="form-control" formControlName="Amount">
+                            <div *ngIf="checkoutForm.get('Amount')?.invalid && checkoutForm.get('Amount')?.touched" class="text-danger">
+                                Amount is required.
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="paymentMode">Payment Mode:</label>
+                            <select class="form-control" id="paymentMode" formControlName="PaymentMode" required>
+                                <option value="">Select Payment Mode</option>
+                                <option *ngFor="let mode of PaymentModes" [value]="mode">{{ mode }}</option>
+                            </select>
+                            <div *ngIf="checkoutForm.get('PaymentMode')?.invalid && checkoutForm.get('PaymentMode')?.touched" class="text-danger">
+                                PaymentMode is required.
+                            </div>
+                        </div>
+                        <div class="mb-3" *ngIf="SelectedPaymentMode === 'Card'">
+                            <div class="mb-1">
+                                <label>Card Number</label>
+                                <input type="number" class="form-control" formControlName="CardNumber">
+                                <div *ngIf="checkoutForm.get('CardNumber')?.invalid && checkoutForm.get('CardNumber')?.touched" class="text-danger">
+                                    Card Number must be 16 digits.
+                                </div>
+                            </div>
+                            <div class="mb-1">
+                                <label>Expiry Date (MM/YY)</label>
+                                <input type="text" class="form-control" formControlName="ExpiryDate">
+                                <div *ngIf="checkoutForm.get('ExpiryDate')?.invalid && checkoutForm.get('ExpiryDate')?.touched" class="text-danger">
+                                    Format: MM/YY
+                                </div>
+                            </div>
+                            <div class="mb-1">
+                                <label>CVV</label>
+                                <input type="number" class="form-control" formControlName="CVV">
+                                <div *ngIf="checkoutForm.get('CVV')?.invalid && checkoutForm.get('CVV')?.touched" class="text-danger">
+                                    CVV must be 3 digits.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="mb-3" *ngIf="SelectedPaymentMode === 'Bank'">
+                            <div class="mb-1">
+                                <label>Bank Name</label>
+                                <input type="text" class="form-control" formControlName="BankName">
+                                <div *ngIf="checkoutForm.get('BankName')?.invalid && checkoutForm.get('BankName')?.touched" class="text-danger">
+                                    Bank Name is required.
+                                </div>
+                            </div>
+                            <div class="mb-1">
+                                <label>Account Number</label>
+                                <input type="text" class="form-control" formControlName="AccountNumber">
+                                <div *ngIf="checkoutForm.get('AccountNumber')?.invalid && checkoutForm.get('AccountNumber')?.touched" class="text-danger">
+                                    AccountNumber is required.
+                                </div>
+                            </div>
+                        </div>
+
+                        <button class="btn btn-success w-100" [disabled]="checkoutForm.invalid">Pay</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/payment/payment-process.component.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/payment/payment-process.component.ts
@@ -1,0 +1,87 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ApiService } from '../service/api.service';
+
+@Component({
+    selector: 'app-payment-process',
+    templateUrl: './payment-process.component.html'
+})
+export class PaymentProcessComponent implements OnInit {
+    checkoutForm!: FormGroup;
+    PaymentModes = ['Card', 'Bank'];
+    SelectedPaymentMode: string = '';
+    @Output('payment-response-callback') PaymentResponseCallBack = new EventEmitter<object>();
+
+    constructor(private fb: FormBuilder, private apiService: ApiService) {
+        this.checkoutForm = this.fb.group({
+            FullName: ['', Validators.required],
+            Email: ['', [Validators.required, Validators.email]],
+            Currency: ['', Validators.required],
+            Amount: [0, Validators.required],
+            PaymentMode: ['', Validators.required],
+            CardNumber: [''],
+            ExpiryDate: [''],
+            CVV: [''],
+            AccountNumber: [''],
+            BankName: ['']
+        });
+
+        this.checkoutForm.get('PaymentMode')?.valueChanges.subscribe((value) => {
+            this.SelectedPaymentMode = value;
+            this.UpdateFormValidators();
+        });
+    }
+
+    UpdateFormValidators(): void {
+        const cardNumberControl = this.checkoutForm.get('CardNumber');
+        const expiryDateControl = this.checkoutForm.get('ExpiryDate');
+        const cvvControl = this.checkoutForm.get('CVV');
+        const accountNumberControl = this.checkoutForm.get('AccountNumber');
+        const bankNameControl = this.checkoutForm.get('BankName');
+
+        if (this.SelectedPaymentMode === 'Card') {
+            cardNumberControl?.setValidators([Validators.required, Validators.pattern(/^\d{16}$/)]);
+            expiryDateControl?.setValidators([Validators.required, Validators.pattern(/^(0[1-9]|1[0-2])\/\d{2}$/)]);
+            cvvControl?.setValidators([Validators.required, Validators.pattern(/^\d{3}$/)]);
+            accountNumberControl?.clearValidators();
+            bankNameControl?.clearValidators();
+        }
+        else if (this.SelectedPaymentMode === 'Bank') {
+            accountNumberControl?.setValidators([Validators.required, Validators.pattern(/^\d{9,18}$/)]);
+            bankNameControl?.setValidators([Validators.required]);
+            cardNumberControl?.clearValidators();
+            expiryDateControl?.clearValidators();
+            cvvControl?.clearValidators();
+        }
+
+        cardNumberControl?.updateValueAndValidity();
+        expiryDateControl?.updateValueAndValidity();
+        cvvControl?.updateValueAndValidity();
+        accountNumberControl?.updateValueAndValidity();
+        bankNameControl?.updateValueAndValidity();
+    }
+
+    ngOnInit(): void {
+    }
+
+
+    submitPayment() {
+        if (this.checkoutForm.valid) {
+            this.apiService.processPayment(this.checkoutForm.value).subscribe({
+                next: (response: any) => {
+                    if (response) {
+                        alert('Payment Successful');
+                        // this.checkoutForm.reset();
+                        this.PaymentResponseCallBack.emit();
+                    } else {
+                        alert('Invalid login response');
+                    }
+                },
+                error: (error) => {
+                    alert('Payment process failed.');
+                }
+            });
+        }
+    }
+}
+

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/service/api.service.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/service/api.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import { TokenRequest_DTO } from '../DTOs/token-request.dto';
 
 @Injectable({
     providedIn: 'root'
@@ -14,7 +15,11 @@ export class ApiService {
     Login(loginRequest: any) {
         return this.http.post(`${this.apiUrl}/Authentication/Login`, loginRequest);
     }
-    // processPayment(paymentData: any): Observable<any> {
-    //     return this.http.post(`${this.apiUrl}/Payment/ProcessPayment`, paymentData);
-    // }
+    processPayment(paymentData: any): Observable<any> {
+        return this.http.post(`${this.apiUrl}/Payment/ProcessPayment`, paymentData);
+    }
+    getNewToken(tokens: TokenRequest_DTO): Observable<any> {
+        return this.http.post(`${this.apiUrl}/Authentication/refresh-token`, tokens);
+    }
+    
 }

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/service/authentication.service.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/service/authentication.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, catchError, Observable, tap, throwError } from 'rxjs';
+import { ApiService } from './api.service';
+import { TokenRequest_DTO } from '../DTOs/token-request.dto';
 
 @Injectable({
     providedIn: 'root'
@@ -10,15 +12,16 @@ export class AuthService {
     private isLoggedInSubject = new BehaviorSubject<boolean>(!!localStorage.getItem('authToken'));
     isLoggedIn$ = this.isLoggedInSubject.asObservable();
 
-    constructor(private router: Router) { }
+    constructor(private router: Router, private apiService: ApiService) { }
 
     CheckIfUserAuthenticated(): boolean {
-        const token = localStorage.getItem('authToken');
+        const token = localStorage.getItem('accessToken');
         return this.isAuthenticated = token ? true : false;
     }
 
-    login(token: string) {
-        localStorage.setItem('authToken', token);
+    setToken(accessToken: string, refreshToken: string) {
+        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
         this.isLoggedInSubject.next(true);
     }
     logout(): void {
@@ -31,7 +34,29 @@ export class AuthService {
         return this.isAuthenticated;
     }
 
-    getToken() {
-        return localStorage.getItem('authToken');
+    getAccessToken() {
+        return localStorage.getItem('accessToken');
+    }
+    getRefreshToken() {
+        return localStorage.getItem('refreshToken');
+    }
+    FetchRefreshToken(TokenRequest: TokenRequest_DTO): Observable<any> {
+        return this.apiService.getNewToken(TokenRequest).pipe(
+            tap((response: any) => {
+                if (response && response.accessToken) {
+                    this.setToken(response.accessToken, response.refreshToken);
+                } else {
+                    alert('Invalid Token');
+                }
+            }),
+            catchError((error) => {
+                alert('Process failed!');
+                return throwError(() => error);
+            })
+        );
+    }
+    clearTokens() {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
     }
 }


### PR DESCRIPTION
**Things Done:**

Added refresh token in interceptor and fixed unwanted logout

- When API returns 401, interceptor now calls refresh token API and retries the request with new token
- Used a shared subject to avoid multiple refresh calls at the same time
- Fixed issue where user was redirected to login even if retried request failed with 500 or other errors
- Now login redirect happens only if refresh token fails