### PR TITLE
Save Refresh token to http-only cookie and save Access token to Sessi…

### DIFF
--- a/PaymentGatewayApp/PaymentGatewayApp.Server/Requests/TokenRequest.cs
+++ b/PaymentGatewayApp/PaymentGatewayApp.Server/Requests/TokenRequest.cs
@@ -3,6 +3,5 @@
     public class TokenRequest
     {
         public string AccessToken { get; set; }
-        public string RefreshToken { get; set; }
     }
 }

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/DTOs/token-request.dto.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/DTOs/token-request.dto.ts
@@ -1,4 +1,3 @@
 export class TokenRequest_DTO{
     public AccessToken: string | null =  '';
-    public RefreshToken: string | null = '';
 }

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/login/login.component.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/login/login.component.ts
@@ -29,8 +29,8 @@ export class LoginComponent implements OnInit {
             this.apiService.Login(this.loginForm.value).subscribe({
                 next: (response: any) => {
                     if (response && response.accessToken) {
-                        this.token = response;
-                        this.authService.setToken(response.accessToken, response.refreshToken);
+                        this.token.AccessToken = response.accessToken;
+                        this.authService.setToken(response.accessToken);
                         this.IsPaymentAllowed = true;
                     } else {
                         alert('Invalid login response');

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/payment/payment-process.component.html
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/payment/payment-process.component.html
@@ -11,6 +11,7 @@
                             <div *ngIf="checkoutForm.get('FullName')?.invalid && checkoutForm.get('FullName')?.touched" class="text-danger">
                                 Name is required.
                             </div>
+                            <!-- <div [innerHTML]="getSanitizedHtml()"></div> -->
                         </div>
                         <div class="mb-1">
                             <label>Email</label>

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/payment/payment-process.component.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/payment/payment-process.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ApiService } from '../service/api.service';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Component({
     selector: 'app-payment-process',
@@ -12,7 +13,7 @@ export class PaymentProcessComponent implements OnInit {
     SelectedPaymentMode: string = '';
     @Output('payment-response-callback') PaymentResponseCallBack = new EventEmitter<object>();
 
-    constructor(private fb: FormBuilder, private apiService: ApiService) {
+    constructor(private fb: FormBuilder, private apiService: ApiService, private sanitizer: DomSanitizer) {
         this.checkoutForm = this.fb.group({
             FullName: ['', Validators.required],
             Email: ['', [Validators.required, Validators.email]],
@@ -31,7 +32,9 @@ export class PaymentProcessComponent implements OnInit {
             this.UpdateFormValidators();
         });
     }
-
+    // getSanitizedHtml(): SafeHtml {
+    //     return this.sanitizer.bypassSecurityTrustHtml(this.checkoutForm.get('FullName')?.value || '');
+    // }
     UpdateFormValidators(): void {
         const cardNumberControl = this.checkoutForm.get('CardNumber');
         const expiryDateControl = this.checkoutForm.get('ExpiryDate');

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/service/api.service.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/service/api.service.ts
@@ -18,8 +18,8 @@ export class ApiService {
     processPayment(paymentData: any): Observable<any> {
         return this.http.post(`${this.apiUrl}/Payment/ProcessPayment`, paymentData);
     }
-    getNewToken(tokens: TokenRequest_DTO): Observable<any> {
-        return this.http.post(`${this.apiUrl}/Authentication/refresh-token`, tokens);
+    getNewToken(token: TokenRequest_DTO): Observable<any> {
+        return this.http.post(`${this.apiUrl}/Authentication/refresh-token`, token);
     }
     
 }

--- a/PaymentGatewayApp/paymentgatewayapp.client/src/app/service/authentication.service.ts
+++ b/PaymentGatewayApp/paymentgatewayapp.client/src/app/service/authentication.service.ts
@@ -9,19 +9,18 @@ import { TokenRequest_DTO } from '../DTOs/token-request.dto';
 })
 export class AuthService {
     private isAuthenticated = false;
-    private isLoggedInSubject = new BehaviorSubject<boolean>(!!localStorage.getItem('authToken'));
+    private isLoggedInSubject = new BehaviorSubject<boolean>(!!sessionStorage.getItem('authToken'));
     isLoggedIn$ = this.isLoggedInSubject.asObservable();
 
     constructor(private router: Router, private apiService: ApiService) { }
 
     CheckIfUserAuthenticated(): boolean {
-        const token = localStorage.getItem('accessToken');
+        const token = sessionStorage.getItem('accessToken');
         return this.isAuthenticated = token ? true : false;
     }
 
-    setToken(accessToken: string, refreshToken: string) {
-        localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('refreshToken', refreshToken);
+    setToken(accessToken: string) {
+        sessionStorage.setItem('accessToken', accessToken);
         this.isLoggedInSubject.next(true);
     }
     logout(): void {
@@ -35,16 +34,13 @@ export class AuthService {
     }
 
     getAccessToken() {
-        return localStorage.getItem('accessToken');
-    }
-    getRefreshToken() {
-        return localStorage.getItem('refreshToken');
+        return sessionStorage.getItem('accessToken');
     }
     FetchRefreshToken(TokenRequest: TokenRequest_DTO): Observable<any> {
         return this.apiService.getNewToken(TokenRequest).pipe(
             tap((response: any) => {
-                if (response && response.accessToken) {
-                    this.setToken(response.accessToken, response.refreshToken);
+                if (response) {
+                    this.setToken(response);
                 } else {
                     alert('Invalid Token');
                 }
@@ -56,7 +52,6 @@ export class AuthService {
         );
     }
     clearTokens() {
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
+        sessionStorage.removeItem('accessToken');
     }
 }


### PR DESCRIPTION
This PR improves authentication token handling for enhanced security and robustness:

**Token Storage Changes**:

- Access Token is now stored in sessionStorage instead of localStorage to reduce exposure to XSS attacks and clear automatically on tab close.

- Refresh Token is no longer stored in the frontend; it is now sent via a secure, HTTP-only cookie from the backend to prevent client-side access.

**Refresh Flow Improvements:**
Refactored the token refresh logic to:

- Only call handleAuthError() when the FetchRefreshToken() request itself fails (e.g., 401/500).

- Prevent handleAuthError() from being triggered by unrelated API failures (like 500 errors from retried API requests).