### PR TITLE
feat: Implement rate limiting with FixedWindow policy to restrict excessive API calls

### DIFF
--- a/PaymentGatewayApp/PaymentGatewayApp.Server/Controllers/PaymentController.cs
+++ b/PaymentGatewayApp/PaymentGatewayApp.Server/Controllers/PaymentController.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.RateLimiting;
 using Newtonsoft.Json;
 using PaymentGatewayApp.Server.DatabaseContext;
 using PaymentGatewayApp.Server.Interfaces;
@@ -31,6 +30,7 @@ namespace PaymentGatewayApp.Server.Controllers
             _logger = logger;
         }
 
+        [EnableRateLimiting("FixedPolicy")]
         [HttpPost("ProcessPayment")]
         public async Task<IActionResult> ProcessPayment([FromBody] PaymentRequests request)
         {
@@ -38,7 +38,7 @@ namespace PaymentGatewayApp.Server.Controllers
             {
                 // Validate the presence and integrity of the Idempotency-Key in the request header
                 if (!HttpContext.Request.Headers.TryGetValue("Idempotency-Key", out var idempotencyKey) ||
-    string.IsNullOrWhiteSpace(idempotencyKey))
+                 string.IsNullOrWhiteSpace(idempotencyKey))
                 {
                     return BadRequest(new { Message = "Missing or invalid Idempotency-Key header." });
                 }


### PR DESCRIPTION
This PR implements a rate limiting mechanism using ASP.NET Core's built-in Rate Limiting middleware.

 **Highlights**:
- Configured a FixedWindow rate limiting policy named "FixedPolicy"
- Allows 1 request per minute per IP, with 1 additional request allowed in queue
- Returns HTTP 429 (Too Many Requests) when the limit is exceeded
- Applied the policy to specific controller actions using [EnableRateLimiting("FixedPolicy")]
- Middleware registered correctly to intercept requests before they hit the controller

**Purpose**:
To prevent abuse and accidental overuse of sensitive endpoints like payment processing by limiting request rates on a per-IP basis.
**Note**:
This setup is scoped per client IP to ensure fair usage without affecting other users.